### PR TITLE
Fix: Comments as defined in ODSReader also covered #DIV/0 etc, skewin…

### DIFF
--- a/ODSReader.py
+++ b/ODSReader.py
@@ -84,14 +84,11 @@ class ODSReader(object):
                             textContent = u'{}{}'.format(textContent, n.data)
 
                 if(textContent):
-                    if(textContent[0] != "#"):  # ignore comments cells
-                        for rr in xrange(int(repeat)):  # repeated?
-                            arrCells[count]=textContent
-                            count+=1
-                    else:
-                        row_comment = row_comment + textContent + " "
+                    for rr in range(int(repeat)):  # repeated?
+                        arrCells[count]=textContent
+                        count+=1
                 else:
-                    for rr in xrange(int(repeat)):
+                    for rr in range(int(repeat)):
                         count+=1
 
             # if row contained something


### PR DESCRIPTION
The treatment of comments makes it ignore all cells which contain invalid calculations or references. The resulting table thus is skewed and misses those cells, giving possibly each line another length.